### PR TITLE
Replace deprecated `append_uint` with `write_uint`

### DIFF
--- a/glib/context.odin
+++ b/glib/context.odin
@@ -183,7 +183,7 @@ create_context :: proc "contextless" () -> (ctx: runtime.Context) {
         proc_cstr := strings.clone_to_cstring(location.procedure)
 
         int_buf: [256]u8
-        line_str := strconv.append_uint(int_buf[:], u64(location.line), 10)
+        line_str := strconv.write_uint(int_buf[:], u64(location.line), 10)
         int_buf[len(line_str)] = 0
         line_cstr := cstring(&int_buf[0])
 
@@ -246,4 +246,3 @@ create_context :: proc "contextless" () -> (ctx: runtime.Context) {
     }
     return
 }
-


### PR DESCRIPTION
I've been getting this warning when building:
```shell
odin-gtk/glib/context.odin(186:29) Warning: append_uint is deprecated: Use write_uint instead 
	... e_str := strconv.append_uint(int_buf[:], u64(location.line), 10) 
	                     ^~~~~~~~~~^ 
```

`append_uint` was calling `write_uint` under the hood anyway.
```odin
append_uint :: proc(buf: []byte, u: u64, base: int) -> string {
	return write_uint(buf, u, base)
}