### PR TITLE
Fixed an aliasing case that crashes the compiler (compiler bug)

### DIFF
--- a/glib/glib.odin
+++ b/glib/glib.odin
@@ -374,7 +374,7 @@ _GMainContext :: struct #packed {}
 MainContext :: _GMainContext
 _GMainLoop :: struct #packed {}
 MainLoop :: _GMainLoop
-Source :: _GSource
+// Source :: _GSource
 _GSourcePrivate :: struct #packed {}
 SourcePrivate :: _GSourcePrivate
 SourceCallbackFuncs :: _GSourceCallbackFuncs
@@ -383,7 +383,7 @@ SourceFunc :: #type proc "c" (user_data: pointer) -> boolean
 SourceOnceFunc :: #type proc "c" (user_data: pointer)
 ChildWatchFunc :: #type proc "c" (pid: Pid, wait_status: int_, user_data: pointer)
 SourceDisposeFunc :: #type proc "c" (source: ^Source)
-_GSource :: struct {
+Source :: struct {
     callback_data: pointer,
     callback_funcs: [^]SourceCallbackFuncs,
     source_funcs: [^]SourceFuncs,


### PR DESCRIPTION
Fixes https://github.com/PucklaJ/odin-gtk/issues/9.

This is related to https://github.com/odin-lang/Odin/issues/5929, a bug in the compiler.

There are likely more cases in the bindings where this issue surfaces, for now we'll have to fix these aliases manually.

---

Aparte: This alone does not fix the issue, needs the `glib.SList` fix from https://github.com/PucklaJ/odin-gtk/pull/8 to be merged as well.