### PR TITLE
Improved template examples to showcase the 'startup' signal

### DIFF
--- a/examples/widget-template-manual/window.odin
+++ b/examples/widget-template-manual/window.odin
@@ -1,148 +1,163 @@
-package template
+/*
+This example registers all the template widgets and GObjects manually.
+*/
+package template_manual
 
 import fmt     "core:fmt"
 import runtime "base:runtime"
 
-import adw     "../../adwaita"
-import gio     "../../glib/gio"
-import glib    "../../glib"
-import gobj    "../../glib/gobject"
-import gtk     "../../gtk"
-
-// Return the GType of our widget, and register it if it isn't already.
-my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
-    @static static_g_type: gobj.Type
-
-    // If the type is already registered, we just return the type id.
-    if static_g_type != 0 { return static_g_type }
-
-    info := gobj.TypeInfo{
-        class_size = size_of(My_Box_Class),
-        class_init = class_init,
-
-        instance_size = size_of(My_Box),
-        instance_init = instance_init,
-    }
-    // We the type id so it sticks.
-    static_g_type = gobj.type_register_static(gtk.box_get_type(), "My_Box", &info, .NONE)
-    g_type = static_g_type
-    return
-
-    // Constructors
-    // These could be defined outside of this proc too, but it's nicer to have them contained here.
-
-    // This handles everything that's related to the overall widget class.
-    class_init :: proc "c" (class: ^gobj.TypeClass, data: glib.pointer) {
-        gtk.widget_class_set_template_from_resource(cast(^gtk.WidgetClass)class, "/example/box.ui")
-
-        // We can set the click action here. See the blueprint `box.blp` for more information.
-        // Alternatively, we could set it in the `instance_init` proc as well.
-        widget_class := cast(^gtk.WidgetClass)class
-        offset := cast(glib.ssize)offset_of(My_Box, button)
-
-        gtk.widget_class_bind_template_child_full(
-            widget_class,
-            name = "my-button",
-            internal_child = false, // I have no idea what this does. Both work (shrug).
-            struct_offset = offset, // This will automatically bind our button into our My_Box struct. How cool!
-        )
-
-        // We set up our button's clicked action defined in the blueprint.
-        // Refer to the `instance_init` proc if you want to set it without blueprint.
-        clicked_callback := cast(gobj.Callback)my_button_clicked
-        gtk.widget_class_bind_template_callback_full(widget_class, "my_button_clicked", clicked_callback)
-
-        // Rest of your class setup and virtual methods etc. go here as well.
-    }
-
-    // This handles the individual instances of the widget.
-    instance_init :: proc "c" (instance: ^gobj.TypeInstance, class_data: glib.pointer) {
-        gtk.widget_init_template(cast(^gtk.Widget)instance)
-
-        /*
-        // We could also set up our child button here instead, if we wanted to.
-
-        button := cast(^gtk.Button)(
-            gtk.widget_get_template_child(cast(^gtk.Widget)instance, my_button_get_type(), "my-button")
-        )
-        my_box := cast(^My_Box)instance
-        my_box.button = button
-
-        // It is, however, important to note that we would need to unset the `my_button_clicked` signal
-        // in the blueprint. It's either-or. Both cannot be true at once, GTK will yell at us otherwise.
-
-        clicked_callback := cast(gobj.Callback)my_button_clicked
-        gobj.signal_connect(button, "clicked", clicked_callback, nil)
-        */
-
-        // Rest of your instance overrides and setup go here as well.
-    }
-
-    // This will get called when we click the button.
-    my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
-        parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
-        my_box := cast(^My_Box)parent
-
-        my_box.button_clicked += 1
-
-        context = runtime.default_context()
-        fmt.printfln("Button clicked %d times!", my_box.button_clicked)
-
-        // GTK copies our string, so we are responsible for freeing the memory.
-        button_clicked_cstring := fmt.caprintf("Clicked %d times!", my_box.button_clicked)
-        defer delete(button_clicked_cstring)
-
-        gtk.button_set_label(button, button_clicked_cstring)
-    }
-}
+import adw  "../../adwaita"
+import gio  "../../glib/gio"
+import glib "../../glib"
+import gobj "../../glib/gobject"
+import gtk  "../../gtk"
 
 // Needed by GTK internally.
 My_Box_Class :: struct {
-    parent_class: gtk.BoxClass,
+	parent_class: gtk.BoxClass,
 }
 
 // The box instance.
 // Note: `parent` field has to be the first.
 My_Box :: struct {
-    parent_instance: gtk.Box,
-    button_clicked: int,
-    button: ^gtk.Button, // this field is set by us in the `class_init` proc.
+	parent_instance: gtk.Box,
+	button_clicked:  int,
+	button:          ^gtk.Button, // this field is set by us in the `class_init` proc.
 }
+
+// Return the GType of our widget, and register it if it isn't already.
+my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
+	@static static_g_type: gobj.Type
+
+	// If the type is already registered, we just return the type id.
+	if static_g_type != 0 { return static_g_type }
+
+	info := gobj.TypeInfo{
+		class_size = size_of(My_Box_Class),
+		class_init = class_init,
+
+		instance_size = size_of(My_Box),
+		instance_init = instance_init,
+	}
+	// We save the type id so it sticks.
+	static_g_type = gobj.type_register_static(gtk.box_get_type(), "My_Box", &info, .NONE)
+	g_type = static_g_type
+	return
+
+	// Constructors
+	// These could be defined outside of this proc too, but it's nicer to have them contained here.
+
+	// This handles everything that's related to the overall widget class.
+	class_init :: proc "c" (class: ^gobj.TypeClass, data: glib.pointer) {
+		gtk.widget_class_set_template_from_resource(cast(^gtk.WidgetClass)class, "/example/box.ui")
+
+		// We can set the click action here. See the blueprint `box.blp` for more information.
+		// Alternatively, we could set it in the `instance_init` proc as well.
+		widget_class := cast(^gtk.WidgetClass)class
+		offset := cast(glib.ssize)offset_of(My_Box, button)
+
+		gtk.widget_class_bind_template_child_full(
+			widget_class,
+			name = "my-button",
+			internal_child = false, // I have no idea what this does. Both work (shrug).
+			struct_offset = offset, // This will automatically bind our button into our My_Box struct. How cool!
+		)
+
+		// We set up our button's clicked action defined in the blueprint.
+		// Refer to the `instance_init` proc if you want to set it without blueprint.
+		clicked_callback := cast(gobj.Callback)my_button_clicked
+		gtk.widget_class_bind_template_callback_full(widget_class, "my_button_clicked", clicked_callback)
+
+		// Rest of your class setup and virtual methods etc. go here as well.
+	}
+
+	// This handles the individual instances of the widget.
+	instance_init :: proc "c" (instance: ^gobj.TypeInstance, class_data: glib.pointer) {
+		gtk.widget_init_template(cast(^gtk.Widget)instance)
+
+		/*
+		// We could also set up our child button here instead, if we wanted to.
+
+		button := cast(^gtk.Button)(
+			gtk.widget_get_template_child(cast(^gtk.Widget)instance, my_button_get_type(), "my-button")
+		)
+		my_box := cast(^My_Box)instance
+		my_box.button = button
+
+		// It is, however, important to note that we would need to unset the `my_button_clicked` signal
+		// in the blueprint. It's either-or. Both cannot be true at once, GTK will yell at us otherwise.
+
+		clicked_callback := cast(gobj.Callback)my_button_clicked
+		gobj.signal_connect(button, "clicked", clicked_callback, nil)
+		*/
+
+		// Rest of your instance overrides and setup go here as well.
+	}
+
+	// This will get called when we click the button.
+	my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
+		parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
+		my_box := cast(^My_Box)parent
+
+		my_box.button_clicked += 1
+
+		context = runtime.default_context()
+		fmt.printfln("Button clicked %d times!", my_box.button_clicked)
+
+		// GTK copies our string, so we are responsible for freeing the memory.
+		button_clicked_cstring := fmt.caprintf("Clicked %d times!", my_box.button_clicked)
+		defer delete(button_clicked_cstring)
+
+		gtk.button_set_label(button, button_clicked_cstring)
+	}
+}
+
 
 main :: proc() {
-    context = glib.create_context()
+	context = glib.create_context()
 
-    // We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
-    gtk.init()
+	// We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
+	gtk.init()
 
-    // We load the resource file that was compiled by `glib-compile-resources`
-    // The `.ui` file was created by blueprint-compiler.
-    // use the `#load` directive for release builds, to bundle it into the app.
-    resource := gio.resource_load(#directory + "box.gresource", nil)
-    gio.resources_register(resource)
+	// We load the resource file that was compiled by `glib-compile-resources`
+	// The `.ui` file was created by blueprint-compiler.
+	// use the `#load` directive for release builds, to bundle it into the app.
+	resource := gio.resource_load(#directory + "box.gresource", nil)
+	gio.resources_register(resource)
 
-    app := adw.application_new("some.example", .NONE)
-    defer gobj.object_unref(app)
+	app := adw.application_new("some.example", .NONE)
+	defer gobj.object_unref(app)
 
-    gobj.signal_connect(app, "activate", cast(gobj.Callback)show_window, nil)
-    status := gio.application_run(cast(^gio.Application)app, 0, nil)
+	Signals: {
+		// This is emitted exactly once when our app is getting set up.
+		gobj.signal_connect(app, "startup", startup)
 
-    if status != 0 {
-        fmt.eprintfln("%#v", "oh no!")
-    }
+		// This can be emitted multiple times while the app is running, so we don't
+		// want to do any initialisation here, just display the window.
+		gobj.signal_connect(app, "activate", show_window)
+	}
+
+	status := gio.application_run(cast(^gio.Application)app, 0, nil)
+	if status != 0 {
+		fmt.eprintfln("%#v", "oh no!")
+	}
 }
 
-// We set up and show the main window here. This could be split up to multiple procs, obviously.
-show_window :: proc "c" (app: ^adw.Application) {
-    // GTK is very cast heavy, unfortunately.
-    // I like to prefix generic variables with `_` as a note to myself.
-    _window := adw.application_window_new(cast(^gtk.Application)(app))
-    window := cast(^adw.ApplicationWindow)_window
+// We run this when the `startup` signal is emitted to set up our window.
+startup :: proc "c" (app: ^gtk.Application) {
+	// I like to prefix generic GTK variables with `_` as a note to myself.
+	_window := adw.application_window_new(app)
+	window := cast(^adw.ApplicationWindow)_window
 
-    // We create our custom box here, initialised as per its init function.
-    my_box_g_type := my_box_get_type()
-    _my_box := gobj.object_new(my_box_g_type, nil)
+	// We create our custom box here, initialised as per its init function.
+	my_box_g_type := my_box_get_type()
+	_my_box := gobj.object_new(my_box_g_type, nil)
 
-    adw.application_window_set_content(window, cast(^gtk.Widget)_my_box)
-    gtk.window_present(cast(^gtk.Window)_window)
+	adw.application_window_set_content(window, cast(^gtk.Widget)_my_box)
+}
+
+// We present the window whenever the `activate` signal is emitted.
+show_window :: proc "c" (app: ^gtk.Application) {
+	window := gtk.application_get_active_window(app)
+	gtk.window_present(window)
 }

--- a/examples/widget-template-with-helper/window.odin
+++ b/examples/widget-template-with-helper/window.odin
@@ -1,164 +1,185 @@
-package template
+/*
+This example uses the helper procedures to register and bind GObjects and widgets in templates.
+There is a manual version as well that shows how to do it without the helpers.
+
+In this particular case, since we're only dealing with a single button and a label, the
+manual version ended up being shorter, but for larger, more complex UI structures, the helpers
+are immensely useful.
+*/
+package template_with_helper
 
 import fmt     "core:fmt"
 import runtime "base:runtime"
 
-import adw     "../../adwaita"
-import gio     "../../glib/gio"
-import glib    "../../glib"
-import gobj    "../../glib/gobject"
-import gtk     "../../gtk"
-import helper    "../../helper"
+import adw    "../../adwaita"
+import gio    "../../glib/gio"
+import glib   "../../glib"
+import gobj   "../../glib/gobject"
+import gtk    "../../gtk"
+import helper "../../helper"
 
 // The box instance.
 // Note: `parent` field has to be the first.
 My_Box :: struct {
-    parent_instance: gtk.Box,
-    button_clicked: int,
-    button: ^gtk.Button,  // This field is populated automatically.
-    button_label: cstring `gproperty:"1,button-label"`,
+	parent_instance: gtk.Box,
+	button_clicked:  int,
+	button:          ^gtk.Button,  // This field is populated automatically.
+	button_label:	  cstring `gproperty:"1,button-label"`,
 }
 
 main :: proc() {
-    context = glib.create_context()
+	context = glib.create_context()
 
-    // We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
-    gtk.init()
+	// We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
+	gtk.init()
 
-    /*
-    We load the resource file that was compiled by `glib-compile-resources`
-    The `.ui` file was created by blueprint-compiler.
-    Here, the resource is loaded from disk on every app start. Useful for development.
+	/*
+	We load the resource file that was compiled by `glib-compile-resources`
+	The `.ui` file was created by blueprint-compiler.
+	Here, the resource is loaded from disk on every app start. Useful for development.
 
-    resource := gio.resource_load(#directory + "box.gresource", nil)
-    gio.resources_register(resource)
-    */
+	resource := gio.resource_load(#directory + "box.gresource", nil)
+	gio.resources_register(resource)
+	*/
 
-    // Here, the resource is bundled into the application, useful for release builds.
-    _, resource_err := helper.register_resource(#load("box.gresource"))
-    if resource_err != nil {
-        // log.fatalf("Could not load resource. Error: %s", resource_err.message)
-        glib.free(resource_err)
-        return
-    }
+	// Here, the resource is bundled into the application, useful for release builds.
+	_, resource_err := helper.register_resource(#load("box.gresource"))
+	if resource_err != nil {
+		// log.fatalf("Could not load resource. Error: %s", resource_err.message)
+		glib.free(resource_err)
+		return
+	}
 
 
-    app := adw.application_new("some.example", .NONE)
-    defer gobj.object_unref(app)
+	app := adw.application_new("some.example", .NONE)
+	defer gobj.object_unref(app)
 
-    gobj.signal_connect(app, "activate", cast(gobj.Callback)show_window, nil)
-    status := gio.application_run(cast(^gio.Application)app, 0, nil)
+	Signals: {
+		// This is emitted exactly once when our app is getting set up.
+		gobj.signal_connect(app, "startup", startup)
 
-    if status != 0 {
-        fmt.eprintfln("%#v", "oh no!")
-    }
-   }
+		// This can be emitted multiple times while the app is running, so we don't
+		// want to do any initialisation here, just display the window.
+		gobj.signal_connect(app, "activate", show_window)
+	}
 
-/* We set up and show the main window here. This could be split up to multiple procs, obviously.
-In that case, we would need to make sure that our template data remains valid and allocated.
+	status := gio.application_run(cast(^gio.Application)app, 0, nil)
 
-See `helper.Template_Data` for more information.
-*/
-show_window :: proc "c" (app: ^adw.Application) {
-    // GTK is very cast heavy, unfortunately.
-    // I like to prefix generic variables with `_` as a note to myself.
-    _window := adw.application_window_new(cast(^gtk.Application)(app))
-    window := cast(^adw.ApplicationWindow)_window
-
-    // If we only care about registering the child, and don't want to bind it to our struct,
-    // we can leave `field_name` empty.
-    template_children := []helper.Template_Child{
-        {
-            id         = "my-button",
-            field_name = "button",
-        },
-    }
-    // See helper.Template_Data for more information about what this is.
-    template_data := helper.Template_Data{
-        resource_path = "/example/box.ui",
-        children = template_children,
-    }
-    helper.register_type(
-        My_Box,
-        gtk.BoxClass,
-        gtk.box_get_type(),
-        &template_data,
-
-        // We want to set a `clicked` signal to our button, so we must supply our own init proc.
-        class_init_proc = my_box_class_init,
-        instance_init_proc = my_box_instance_init,
-    )
-
-    // We create our custom box here, initialised as per its init function.
-    my_box_g_type := helper.custom_type_get_type(My_Box)
-    _my_box := gobj.object_new(my_box_g_type, nil)
-
-    adw.application_window_set_content(window, cast(^gtk.Widget)_my_box)
-    gtk.window_present(cast(^gtk.Window)_window)
+	if status != 0 {
+	   fmt.eprintfln("%#v", "oh no!")
+	}
 }
 
-/*
-Our custom class init proc, since we want to set the `clicked` action on our button.
+// We run this when the `startup` signal is emitted to set up our window.
+startup :: proc "c" (app: ^gtk.Application) {
+	// I like to prefix generic variables with `_` as a note to myself.
+	_window := adw.application_window_new(app)
+	window := cast(^adw.ApplicationWindow)_window
 
-**Note**: This is called only once, when the first object is created.
-*/
-my_box_class_init :: proc "c" (class: ^gobj.TypeClass, data: glib.pointer) {
-    // We register the getter and setter procs for our box's custom gproperties.
-    object_class := cast(^gobj.ObjectClass)class
-    object_class.get_property = my_box_property_get
-    object_class.set_property = my_box_property_set
+	// If we only care about registering the child, and don't want to bind it to our struct,
+	// we can leave `field_name` empty.
+	template_children := []helper.Template_Child{
+	   {
+		  id         = "my-button",
+		  field_name = "button",
+	   },
+	}
 
-    // We call the default init proc, so that we don't have to do the child binding and template setup ourselves.
-    // This takes care of common use cases like registering children and annotated gproperties.
-    helper.class_init_default(class, data)
+	// See helper.Template_Data for more information about what this is.
+	template_data := helper.Template_Data{
+	   resource_path = "/example/box.ui",
+	   children = template_children,
+	}
 
-    // We register our proc as a callback to the signal defined in the blueprint.
-    // Alternatively, we could register the signal in the `instance_init` proc too.
-    widget_class := cast(^gtk.WidgetClass)class
-    clicked_callback := cast(gobj.Callback)my_button_clicked
-    gtk.widget_class_bind_template_callback_full(widget_class, "my_button_clicked", clicked_callback)
+	helper.register_type(
+	   My_Box,
+	   gtk.BoxClass,
+	   gtk.box_get_type(),
+	   &template_data,
+
+	   // We want to set a `clicked` signal to our button, so we must supply our own init proc.
+	   class_init_proc = my_box_class_init,
+	   instance_init_proc = my_box_instance_init,
+	)
+
+	// We create our custom box here, initialised as per its init function.
+	my_box_g_type := helper.custom_type_get_type(My_Box)
+	_my_box := gobj.object_new(my_box_g_type, nil)
+
+	adw.application_window_set_content(window, cast(^gtk.Widget)_my_box)
+
+
+	/*
+	Our custom class init proc, since we want to set the `clicked` action on our button.
+
+	**Note**: This is called only once, when the first object is created.
+	*/
+	my_box_class_init :: proc "c" (class: ^gobj.TypeClass, data: glib.pointer) {
+		// We register the getter and setter procs for our box's custom gproperties.
+		object_class := cast(^gobj.ObjectClass)class
+		object_class.get_property = my_box_property_get
+		object_class.set_property = my_box_property_set
+
+		// We call the default init proc, so that we don't have to do the child binding and template setup ourselves.
+		// This takes care of common use cases like registering children and annotated gproperties.
+		helper.class_init_default(class, data)
+
+		// We register our proc as a callback to the signal defined in the blueprint.
+		// Alternatively, we could register the signal in the `instance_init` proc too.
+		widget_class := cast(^gtk.WidgetClass)class
+		clicked_callback := cast(gobj.Callback)my_button_clicked
+		gtk.widget_class_bind_template_callback_full(widget_class, "my_button_clicked", clicked_callback)
+	}
+
+	// This is called every time a new object instance is created.
+	my_box_instance_init :: proc "c" (instance: ^gobj.TypeInstance, class_data: glib.pointer) {
+		// We call the default template to do the setup.
+		helper.instance_init_default(instance, class_data)
+
+		// We set a default value for our label, since the binding sets none by itself.
+		my_box := cast(^My_Box)instance
+		gtk.button_set_label(my_box.button, "Click me!")
+	}
+
+	// This is called by GTK whenever it wants to know the value of any of the registered properties.
+	my_box_property_get :: proc "c" (object: ^gobj.Object, property_id: glib.uint_, value: ^gobj.Value, pspec: ^gobj.ParamSpec) {
+		my_box := cast(^My_Box)object
+		switch property_id {
+		// We set the id of our property to 1 the struct declaration. See My_Box.button_label at the beginning of the file.
+		case 1:
+		   gobj.value_set_string(value, my_box.button_label)
+		}
+	}
+
+
+	// We can leave this empty for now because we don't plan on setting it through GTK.
+	my_box_property_set :: proc "c" (object: ^gobj.Object, property_id: glib.uint_, value: ^gobj.Value, pspec: ^gobj.ParamSpec) {}
+
+	// This will get called when we click the button.
+	my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
+		parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
+		my_box := cast(^My_Box)parent
+
+		my_box.button_clicked += 1
+
+		context = runtime.default_context()
+		fmt.printfln("Button clicked %d times!", my_box.button_clicked)
+
+		// We free the old button label and allocate the new one.
+		delete(my_box.button_label)
+		button_clicked_cstring := fmt.caprintf("Clicked %d times!", my_box.button_clicked)
+		my_box.button_label = button_clicked_cstring
+
+		// We set the property of our box, and tell GTK that it changed, which will automatically update everything that depends on it.
+		gobj.object_notify(cast(^gobj.Object)my_box, "button-label")
+
+		// In this case, we could have set the button label directly too, via:
+		// gtk.button_set_label(button, button_clicked_cstring)
+	}
 }
 
-// This is called every time a new object instance is created.
-my_box_instance_init :: proc "c" (instance: ^gobj.TypeInstance, class_data: glib.pointer) {
-    // We call the default template to do the setup.
-    helper.instance_init_default(instance, class_data)
-
-    // We set a default value for our label, since the binding sets none by itself.
-    my_box := cast(^My_Box)instance
-    gtk.button_set_label(my_box.button, "Click me!")
-}
-
-// This is called by GTK whenever it wants to know the value of any of the registered properties.
-my_box_property_get :: proc "c" (object: ^gobj.Object, property_id: glib.uint_, value: ^gobj.Value, pspec: ^gobj.ParamSpec) {
-    my_box := cast(^My_Box)object
-    switch property_id {
-    case 1: // We set the id of our property to 1.
-        gobj.value_set_string(value, my_box.button_label)
-    }
-}
-
-
-// We can leave this empty for now because we don't plan on setting it through GTK.
-my_box_property_set :: proc "c" (object: ^gobj.Object, property_id: glib.uint_, value: ^gobj.Value, pspec: ^gobj.ParamSpec) {}
-
-// This will get called when we click the button.
-my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
-    parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
-    my_box := cast(^My_Box)parent
-
-    my_box.button_clicked += 1
-
-    context = runtime.default_context()
-    fmt.printfln("Button clicked %d times!", my_box.button_clicked)
-
-    button_clicked_cstring := fmt.caprintf("Clicked %d times!", my_box.button_clicked)
-
-    // We set the property of our box, and tell GTK that it changed, which will automatically update everything that depends on it.
-    delete(my_box.button_label)
-    my_box.button_label = button_clicked_cstring
-    gobj.object_notify(cast(^gobj.Object)my_box, "button-label")
-
-    // In this case, we could have set the button label directly too, via:
-    // gtk.button_set_label(button, button_clicked_cstring)
+// We present the window whenever the `activate` signal is emitted.
+show_window :: proc "c" (app: ^gtk.Application) {
+	window := gtk.application_get_active_window(app)
+	gtk.window_present(window)
 }


### PR DESCRIPTION
The previous example packed everything into the `activate` signal, which is fine for most cases, but the "best practice" is to use the separate `startup` signal for setup, and just show the window again when activated.

Additional info: `activate` is called whenever the app is run. Gnome uses this to bring an app into focus when the user launches it again, for example after minimising. Hence, it can be called an arbitrary number of times in an app's life cycle, whereas `startup` is called exactly once.

Added some additional comment for clarification too.