### PR TITLE
Improve clarity and correctness of examples

### DIFF
--- a/examples/gtk-layer-shell/gtk-layer-shell.odin
+++ b/examples/gtk-layer-shell/gtk-layer-shell.odin
@@ -17,6 +17,7 @@ main :: proc() {
     defer gobj.object_unref(app)
 
     gobj.signal_connect(app, "activate", activate)
+    gobj.signal_connect(app, "startup",  startup)
 
     status := gio.application_run(app)
 
@@ -25,7 +26,7 @@ main :: proc() {
     }
 }
 
-activate :: proc "c" (app: ^gtk.Application, user_data: glib.pointer) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.WINDOW(gtk.application_window_new(app))
 
     css := gtk.css_provider_new()
@@ -64,6 +65,10 @@ Shell example!
     gtk.box_append(box, button)
 
     gtk.window_set_child(window, cast(^gtk.Widget)box)
+}
+
+activate :: proc "c" (app: ^gtk.Application, _: rawptr) {
+    window  := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }
 

--- a/examples/gtk-snake/gtk-snake.odin
+++ b/examples/gtk-snake/gtk-snake.odin
@@ -630,13 +630,14 @@ main :: proc() {
     defer gobj.object_unref(app)
 
     gobj.signal_connect(app, "activate", activate)
+    gobj.signal_connect(app, "startup",  startup)
 
     status := gio.application_run(app)
 
     assert(status == 0)
 }
 
-activate :: proc "c" (app: ^gtk.Application, user_data: glib.pointer) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.WINDOW(gtk.application_window_new(app))
 
     gtk.window_set_default_size(
@@ -663,5 +664,9 @@ activate :: proc "c" (app: ^gtk.Application, user_data: glib.pointer) {
     gobj.signal_connect(drawing_area, "realize", init)
 
     gtk.window_set_child(window, gtk.WIDGET(drawing_area))
+}
+
+activate :: proc "c" (app: ^gtk.Application, _: rawptr) {
+    window := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }

--- a/examples/hello-adwaita/hello-adwaita.odin
+++ b/examples/hello-adwaita/hello-adwaita.odin
@@ -7,7 +7,7 @@ import gobj "../../glib/gobject"
 import gtk "../../gtk"
 import "core:os"
 
-activate_cb :: proc "c" (app: ^gtk.Application) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.WINDOW(gtk.application_window_new(app))
 
     label := gtk.label_new("Hello, enjoy this spinner :-)")
@@ -29,6 +29,10 @@ activate_cb :: proc "c" (app: ^gtk.Application) {
     gtk.window_set_title(window, "Hello Libadwaita")
     gtk.window_set_default_size(window, 200, 200)
     gtk.window_set_child(window, gtk.WIDGET(box))
+}
+
+activate :: proc "c" (app: ^gtk.Application, _: rawptr) {
+    window := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }
 
@@ -65,8 +69,10 @@ main :: proc() {
     context = glib.create_context()
 
     app := adw.application_new("runic.hello-adwaita", .NONE)
+    defer gobj.object_unref(app)
 
-    gobj.signal_connect(app, "activate", activate_cb)
+    gobj.signal_connect(app, "activate", activate)
+    gobj.signal_connect(app, "startup",  startup)
 
     status := gio.application_run(app)
     if status != 0 {

--- a/examples/hello-gtk/hello-gtk.odin
+++ b/examples/hello-gtk/hello-gtk.odin
@@ -5,13 +5,12 @@ import "../../glib/gio"
 import gobj "../../glib/gobject"
 import "../../gtk"
 import "core:os"
-import "core:strings"
 
-on_button_clicked :: proc "c" (button: ^gtk.Button, user_data: glib.pointer) {
+on_button_clicked :: proc "c" (button: ^gtk.Button, _: rawptr) {
     glib.print("Button clicked! >///<\n")
 }
 
-activate :: proc "c" (app: ^gtk.Application, user_data: glib.pointer) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.WINDOW(gtk.application_window_new(app))
     gtk.window_set_title(window, "Window")
     gtk.window_set_default_size(window, 640, 480)
@@ -21,28 +20,24 @@ activate :: proc "c" (app: ^gtk.Application, user_data: glib.pointer) {
     gtk.window_set_child(window, button)
 
     gobj.signal_connect(button, "clicked", on_button_clicked)
+}
 
+activate :: proc "c" (app: ^gtk.Application, _: rawptr) {
+    window := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }
 
 main :: proc() {
-    context = glib.create_context()
-
     app := gtk.application_new(
         "org.runic.hello-gtk",
         .APPLICATION_DEFAULT_FLAGS,
     )
-    gobj.signal_connect(app, "activate", activate)
+    defer gobj.object_unref(app)
 
-    argv := make([]cstring, len(os.args))
-    for &arg, idx in argv {
-        arg = strings.clone_to_cstring(os.args[idx])
-    }
-    defer delete(argv)
-    defer for arg in argv do delete(arg)
+    gobj.signal_connect(app, "activate", activate)
+    gobj.signal_connect(app, "startup",  startup)
 
     status := gio.application_run(app)
-    gobj.object_unref(app)
 
     if status != 0 {
         os.exit(int(status))

--- a/examples/widget-template-manual/window.odin
+++ b/examples/widget-template-manual/window.odin
@@ -161,13 +161,13 @@ main :: proc() {
 startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     // I like to prefix generic GTK variables with `_` as a note to myself.
     _window := adw.application_window_new(app)
-    window := cast(^adw.ApplicationWindow)_window
+    window := adw.APPLICATION_WINDOW(_window)
 
     // We create our custom box here, initialised as per its init function.
     my_box_g_type := my_box_get_type()
     _my_box := gobj.object_new(my_box_g_type, nil)
 
-    adw.application_window_set_content(window, cast(^gtk.Widget)_my_box)
+    adw.application_window_set_content(window, gtk.WIDGET(_my_box))
 }
 
 // We present the window whenever the `activate` signal is emitted.

--- a/examples/widget-template-manual/window.odin
+++ b/examples/widget-template-manual/window.odin
@@ -52,7 +52,7 @@ my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
     // These could be defined outside of this proc too, but it's nicer to have them contained here.
 
     // This handles everything that's related to the overall widget class.
-    class_init :: proc "c" (class: ^gobj.TypeClass, data: glib.pointer) {
+    class_init :: proc "c" (class: ^gobj.TypeClass, _: rawptr) {
         gtk.widget_class_set_template_from_resource(
             cast(^gtk.WidgetClass)class,
             "/example/box.ui",
@@ -83,10 +83,7 @@ my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
     }
 
     // This handles the individual instances of the widget.
-    instance_init :: proc "c" (
-        instance: ^gobj.TypeInstance,
-        class_data: glib.pointer,
-    ) {
+    instance_init :: proc "c" (instance: ^gobj.TypeInstance, _: rawptr) {
         gtk.widget_init_template(gtk.WIDGET(instance))
 
         /*
@@ -109,7 +106,7 @@ my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
     }
 
     // This will get called when we click the button.
-    my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
+    my_button_clicked :: proc "c" (button: ^gtk.Button, _: rawptr) {
         parent := gtk.widget_get_parent(gtk.WIDGET(button))
         my_box := cast(^My_Box)parent
 
@@ -131,9 +128,9 @@ my_box_get_type :: proc "contextless" () -> (g_type: gobj.Type) {
 
 
 main :: proc() {
-    context = glib.create_context()
-
     // We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
+    // Normally this is called automatically during the `startup` signal, but we
+    // register things before that.
     gtk.init()
 
     // We load the resource file that was compiled by `glib-compile-resources`
@@ -161,7 +158,7 @@ main :: proc() {
 }
 
 // We run this when the `startup` signal is emitted to set up our window.
-startup :: proc "c" (app: ^gtk.Application) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     // I like to prefix generic GTK variables with `_` as a note to myself.
     _window := adw.application_window_new(app)
     window := cast(^adw.ApplicationWindow)_window
@@ -174,7 +171,7 @@ startup :: proc "c" (app: ^gtk.Application) {
 }
 
 // We present the window whenever the `activate` signal is emitted.
-show_window :: proc "c" (app: ^gtk.Application) {
+show_window :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }

--- a/examples/widget-template-with-helper/window.odin
+++ b/examples/widget-template-with-helper/window.odin
@@ -28,9 +28,9 @@ My_Box :: struct {
 }
 
 main :: proc() {
-    context = glib.create_context()
-
     // We must initialise GTK, otherwise our parent class, `gtk.Box` is not valid.
+    // Normally this is called automatically during the `startup` signal, but we
+    // register things before that.
     gtk.init()
 
     /*
@@ -71,7 +71,7 @@ main :: proc() {
 }
 
 // We run this when the `startup` signal is emitted to set up our window.
-startup :: proc "c" (app: ^gtk.Application) {
+startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
     // I like to prefix generic variables with `_` as a note to myself.
     _window := adw.application_window_new(app)
     window := adw.APPLICATION_WINDOW(_window)
@@ -173,7 +173,7 @@ startup :: proc "c" (app: ^gtk.Application) {
     ) {}
 
     // This will get called when we click the button.
-    my_button_clicked :: proc "c" (button: ^gtk.Button, data: glib.pointer) {
+    my_button_clicked :: proc "c" (button: ^gtk.Button, _: rawptr) {
         parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
         my_box := cast(^My_Box)parent
 
@@ -199,7 +199,7 @@ startup :: proc "c" (app: ^gtk.Application) {
 }
 
 // We present the window whenever the `activate` signal is emitted.
-show_window :: proc "c" (app: ^gtk.Application) {
+show_window :: proc "c" (app: ^gtk.Application, _: rawptr) {
     window := gtk.application_get_active_window(app)
     gtk.window_present(window)
 }

--- a/examples/widget-template-with-helper/window.odin
+++ b/examples/widget-template-with-helper/window.odin
@@ -174,7 +174,7 @@ startup :: proc "c" (app: ^gtk.Application, _: rawptr) {
 
     // This will get called when we click the button.
     my_button_clicked :: proc "c" (button: ^gtk.Button, _: rawptr) {
-        parent := gtk.widget_get_parent(cast(^gtk.Widget)button)
+        parent := gtk.widget_get_parent(gtk.WIDGET(button))
         my_box := cast(^My_Box)parent
 
         my_box.button_clicked += 1


### PR DESCRIPTION
- Add a `startup` procedure to be called in addition to `activate`. All setup chores were moved to `startup`, since `activate` can be emitted multiple times.
- Add the `user_data` parameter everywhere to better indicate the passed params (also for technically correct ABI) 